### PR TITLE
STEP11 대용량 트래픽 & 데이터 처리 기본과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,15 @@ dependencies {
 	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// Redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.16.3'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -51,6 +56,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
+	testImplementation 'org.testcontainers:testcontainers:1.19.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
@@ -65,6 +71,8 @@ tasks.named('asciidoctor') {
 }
 
 tasks.withType(Test) {
+	jvmArgs '-Dfile.encoding=UTF-8'
+	systemProperty 'file.encoding', 'UTF-8'
 	useJUnitPlatform()
 	systemProperty 'user.timezone', 'UTC'
 }

--- a/src/main/java/io/hhplus/concert/domain/reservation/DistributedLock.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/DistributedLock.java
@@ -1,0 +1,16 @@
+package io.hhplus.concert.domain.reservation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key();
+    long waitTime() default 5L;
+    long leaseTime() default 3L;
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/RedisDistributedLockAspect.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/RedisDistributedLockAspect.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Order;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
-
-import java.lang.reflect.Method;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Order(1)
 @Aspect
@@ -22,19 +22,17 @@ public class RedisDistributedLockAspect {
 
     private static final String LOCK_PREFIX = "LOCK:";
 
-    private final RedissonClient redissonClient; // RedissonConfig 에서 만든 RedissonClient 를 주입
+    private final RedissonClient redissonClient;
 
     @Around("@annotation(distributedLock)")
     public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
 
         String dynamicKey = SpELParser.getDynamicKey(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
         String lockName = LOCK_PREFIX + dynamicKey;
 
         RLock rLock = redissonClient.getLock(lockName);
-
-        boolean available = false;
+        boolean available;
 
         try {
             available = rLock.tryLock(
@@ -47,12 +45,72 @@ public class RedisDistributedLockAspect {
                 throw new IllegalStateException("락 획득 실패: " + lockName);
             }
 
+            // 트랜잭션 동기화 후 unlock 등록
+            registerLockReleaseAfterTransaction(rLock);
+
             return joinPoint.proceed();
 
-        } finally {
-            if (available && rLock.isHeldByCurrentThread()) {
-                rLock.unlock();
+        } catch (Exception e) {
+            log.error("분산 락 처리 중 예외 발생", e);
+            throw e;
+        }
+    }
+
+
+    /**
+     * 트랜잭션 커밋 후 또는 트랜잭션이 활성화되지 않았을 때 락을 해제하는 트랜잭션 핸들러
+     */
+    private class LockReleaseTransactionSynchronization implements TransactionSynchronization {
+        private final RLock rLock;
+
+        public LockReleaseTransactionSynchronization(RLock rLock) {
+            this.rLock = rLock;
+        }
+
+        /**
+         * 트랜잭션의 커밋 이후에 락을 해제
+         */
+        @Override
+        public void afterCommit() {
+            releaseLock(rLock);
+        }
+
+        /**
+         * 트랜잭션의 상태가 롤백일 때 락을 해제
+         */
+        @Override
+        public void afterCompletion(int status) {
+            if (status != STATUS_COMMITTED) {
+                releaseLock(rLock);
             }
+        }
+    }
+
+    /**
+     * 트랜잭션이 활성화된 경우, 트랜잭션 종료 시 락을 해제하도록 콜백을 등록,
+     * 그렇지 않은 경우 즉시 락을 해제.
+     */
+    private void registerLockReleaseAfterTransaction(RLock rLock) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new LockReleaseTransactionSynchronization(rLock)
+            );
+        } else {
+            releaseLock(rLock);
+        }
+    }
+
+    /**
+     * 현재 스레드가 갖고 있는 락을 해제
+     */
+    private void releaseLock(RLock rLock) {
+        try {
+            if (rLock.isHeldByCurrentThread()) {
+                rLock.unlock();
+                log.debug("락 해제 완료");
+            }
+        } catch (Exception e) {
+            log.error("락 해제 중 예외 발생", e);
         }
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/reservation/RedisDistributedLockAspect.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/RedisDistributedLockAspect.java
@@ -1,0 +1,58 @@
+package io.hhplus.concert.domain.reservation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Order;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Order(1)
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisDistributedLockAspect {
+
+    private static final String LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient; // RedissonConfig 에서 만든 RedissonClient 를 주입
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        String dynamicKey = SpELParser.getDynamicKey(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        String lockName = LOCK_PREFIX + dynamicKey;
+
+        RLock rLock = redissonClient.getLock(lockName);
+
+        boolean available = false;
+
+        try {
+            available = rLock.tryLock(
+                    distributedLock.waitTime(),
+                    distributedLock.leaseTime(),
+                    distributedLock.timeUnit()
+            );
+
+            if (!available) {
+                throw new IllegalStateException("락 획득 실패: " + lockName);
+            }
+
+            return joinPoint.proceed();
+
+        } finally {
+            if (available && rLock.isHeldByCurrentThread()) {
+                rLock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/RedisProperties.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/RedisProperties.java
@@ -1,0 +1,16 @@
+package io.hhplus.concert.domain.reservation;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "spring.redis")
+@Component
+@Getter
+@Setter
+public class RedisProperties {
+    private String host;
+    private int port;
+}
+

--- a/src/main/java/io/hhplus/concert/domain/reservation/RedissonConfig.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/RedissonConfig.java
@@ -1,0 +1,23 @@
+package io.hhplus.concert.domain.reservation;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedissonConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisProperties.getHost() + ":" + redisProperties.getPort());
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
@@ -26,27 +26,31 @@ public class ReservationService {
      * @return ReservationInfo.TemporaryReserve
      * @throws BusinessException
      */
+    @DistributedLock(key = "#command.concertSeat().id")
     @Transactional
     public ReservationInfo.TemporaryReserve temporaryReserve(ReservationCommand.TemporaryReserve command) {
-        try{
-            // 기존 예약 이력 확인
-            Reservation reservation = reservationRepository.findByConcertSeatIdAndUserId(
-                command.user().getId(), command.concertSeat().getId()
-            );
-            // 신규이력생성
-            if(reservation == null) reservation = initTemporaryReservedStatus(command.user(),command.concertSeat());
-            // 임시예약
-            reservation.temporaryReserve();
-            // 임시예약 상태면 좌석도 점유되어있으므로 데이터베이스에 저장
-            concertSeatRepository.saveOrUpdate(reservation.getConcertSeat());
-            // 임시예약 상태의 예약 정보를 데이터베이스에 저장
-            reservationRepository.saveOrUpdate(reservation);
-            return ReservationInfo.TemporaryReserve.from(reservation);
+//        try{
+//            // 기존 예약 이력 확인
+        Reservation reservation = reservationRepository.findByConcertSeatIdAndUserId(
+            command.user().getId(), command.concertSeat().getId()
+        );
+        // 신규이력생성
+        if(reservation == null) reservation = initTemporaryReservedStatus(command.user(),command.concertSeat());
 
-        } catch(OptimisticLockException e) {
-            // 좌석의 version이 일치하지 않으면 예외발생
-            throw new BusinessException(ALREADY_RESERVED);
-        }
+        // 임시예약
+        reservation.temporaryReserve();
+
+        // 임시예약 상태면 좌석도 점유되어있으므로 데이터베이스에 저장
+        concertSeatRepository.saveOrUpdate(reservation.getConcertSeat());
+        // 임시예약 상태의 예약 정보를 데이터베이스에 저장
+        reservationRepository.saveOrUpdate(reservation);
+
+        return ReservationInfo.TemporaryReserve.from(reservation);
+
+//        } catch(OptimisticLockException e) {
+//            // 좌석의 version이 일치하지 않으면 예외발생
+//            throw new BusinessException(ALREADY_RESERVED);
+//        }
     }
     /**
      * 신규 임시예약 상태 예약도메인 생성

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
@@ -26,7 +26,7 @@ public class ReservationService {
      * @return ReservationInfo.TemporaryReserve
      * @throws BusinessException
      */
-    @DistributedLock(key = "#command.concertSeat().id")
+    @DistributedLock(key = "'concert_seat:' + #command.concertSeat().id")
     @Transactional
     public ReservationInfo.TemporaryReserve temporaryReserve(ReservationCommand.TemporaryReserve command) {
 //        try{

--- a/src/main/java/io/hhplus/concert/domain/reservation/SpELParser.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/SpELParser.java
@@ -1,0 +1,21 @@
+package io.hhplus.concert.domain.reservation;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class SpELParser {
+
+    private static final ExpressionParser parser = new SpelExpressionParser();
+
+    public static String getDynamicKey(String[] paramNames, Object[] args, String keyExpression) {
+        EvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/user/RedisConfig.java
+++ b/src/main/java/io/hhplus/concert/domain/user/RedisConfig.java
@@ -1,0 +1,26 @@
+package io.hhplus.concert.domain.user;
+
+import io.hhplus.concert.domain.reservation.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(LettuceConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}
+

--- a/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLock.java
+++ b/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLock.java
@@ -1,0 +1,14 @@
+package io.hhplus.concert.domain.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisSimpleLock {
+    String key(); // SpEL 표현식
+    long timeout() default 5000; // 락 획득 대기 시간 (ms)
+}
+

--- a/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLockAspect.java
+++ b/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLockAspect.java
@@ -1,0 +1,62 @@
+package io.hhplus.concert.domain.user;
+
+import io.hhplus.concert.domain.reservation.SpELParser;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Order;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Order(1)
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RedisSimpleLockAspect {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String LOCK_PREFIX = "Lock:";
+
+    @Around("@annotation(redisSimpleLock)")
+    public Object around(ProceedingJoinPoint joinPoint, RedisSimpleLock redisSimpleLock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+
+        String dynamicKey = SpELParser.getDynamicKey(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                redisSimpleLock.key()
+        );
+        String lockKey = LOCK_PREFIX + dynamicKey;
+
+        String lockValue = UUID.randomUUID().toString();
+        boolean acquired = false;
+        long endTime = System.currentTimeMillis() + redisSimpleLock.timeout();
+
+        try {
+            acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(lockKey, lockValue, Duration.ofSeconds(5));
+
+            if (!acquired) {
+                System.out.println("❌ 락 획득 실패: " + lockKey);
+                throw new IllegalStateException("Redis Simple Lock 획득 실패: " + lockKey);
+            }
+
+            System.out.println("✅ 락 획득 성공: " + lockKey);  // 디버그
+
+            return joinPoint.proceed();
+
+        } finally {
+            String currentValue = redisTemplate.opsForValue().get(lockKey);
+            if (lockValue.equals(currentValue)) {
+                redisTemplate.delete(lockKey);
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLockAspect.java
+++ b/src/main/java/io/hhplus/concert/domain/user/RedisSimpleLockAspect.java
@@ -2,6 +2,7 @@ package io.hhplus.concert.domain.user;
 
 import io.hhplus.concert.domain.reservation.SpELParser;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -13,48 +14,55 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Order(1)
 @Aspect
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RedisSimpleLockAspect {
-
     private final StringRedisTemplate redisTemplate;
     private static final String LOCK_PREFIX = "Lock:";
 
     @Around("@annotation(redisSimpleLock)")
     public Object around(ProceedingJoinPoint joinPoint, RedisSimpleLock redisSimpleLock) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String lockKey = getLockKey(signature, joinPoint, redisSimpleLock);
+        String lockValue = UUID.randomUUID().toString();
 
+        acquireLock(lockKey, lockValue, redisSimpleLock);
+        try {
+            return joinPoint.proceed();
+        } finally {
+            releaseLock(lockKey, lockValue);
+        }
+    }
+
+    private String getLockKey(MethodSignature signature, ProceedingJoinPoint joinPoint, RedisSimpleLock redisSimpleLock) {
         String dynamicKey = SpELParser.getDynamicKey(
                 signature.getParameterNames(),
                 joinPoint.getArgs(),
                 redisSimpleLock.key()
         );
-        String lockKey = LOCK_PREFIX + dynamicKey;
 
-        String lockValue = UUID.randomUUID().toString();
-        boolean acquired = false;
-        long endTime = System.currentTimeMillis() + redisSimpleLock.timeout();
+        return LOCK_PREFIX + dynamicKey;
+    }
 
-        try {
-            acquired = redisTemplate.opsForValue()
-                    .setIfAbsent(lockKey, lockValue, Duration.ofSeconds(5));
+    private void acquireLock(String lockKey, String lockValue, RedisSimpleLock redisSimpleLock) {
+        boolean acquired = redisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(5));
+        if (!acquired) {
+            log.error("❌ 락 획득 실패: {}", lockKey);
+            throw new IllegalStateException("Redis Simple Lock acquisition failed: " + lockKey);
+        }
+        log.debug("✅ 락 획득 성공: {}", lockKey);
+    }
 
-            if (!acquired) {
-                System.out.println("❌ 락 획득 실패: " + lockKey);
-                throw new IllegalStateException("Redis Simple Lock 획득 실패: " + lockKey);
-            }
-
-            System.out.println("✅ 락 획득 성공: " + lockKey);  // 디버그
-
-            return joinPoint.proceed();
-
-        } finally {
-            String currentValue = redisTemplate.opsForValue().get(lockKey);
-            if (lockValue.equals(currentValue)) {
-                redisTemplate.delete(lockKey);
-            }
+    private void releaseLock(String lockKey, String lockValue) {
+        String currentValue = redisTemplate.opsForValue().get(lockKey);
+        if (lockValue.equals(currentValue)) {
+            redisTemplate.delete(lockKey);
         }
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -21,6 +21,7 @@ public class UserService {
      * @param command
      * @return UserInfo.UserPoint
      */
+    @RedisSimpleLock(key = "'user_point:' + #command.userId", timeout = 3000)
     @Transactional
     public UserInfo.ChargePoint chargePoint(UserPointCommand.ChargePoint command) {
         // 유저 포인트정보 조회

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
      * @param command
      * @return UserInfo.UserPoint
      */
-    @RedisSimpleLock(key = "'user_point:' + #command.userId", timeout = 3000)
+    @RedisSimpleLock(key = "'user_point:' + #command.userId")
     @Transactional
     public UserInfo.ChargePoint chargePoint(UserPointCommand.ChargePoint command) {
         // 유저 포인트정보 조회
@@ -44,6 +44,7 @@ public class UserService {
      * @param command
      * @return UserInfo.UserPoint
      */
+    @RedisSimpleLock(key = "'user_point:' + #command.userId")
     @Transactional
     public UserInfo.UsePoint usePoint(UserPointCommand.UsePoint command) {
         // 유저 정보 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,9 @@ spring:
     redis:
       host: localhost
       port: 6379
-
+logging:
+  level:
+    io.hhplus.concert: DEBUG
 ---
 spring.config.activate.on-profile: local, test
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: hhplus-concert
+    name: hhplus
   profiles:
     active: local
   datasource:
@@ -16,10 +16,15 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 ---
 spring.config.activate.on-profile: local, test
@@ -29,9 +34,3 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
-springdoc:
-  api-docs:
-    path: /v3/api-docs
-  swagger-ui:
-    path: /swagger-ui.html
-    operationSorter: method

--- a/src/test/java/io/hhplus/concert/TestcontainersConfiguration.java
+++ b/src/test/java/io/hhplus/concert/TestcontainersConfiguration.java
@@ -3,34 +3,53 @@ package io.hhplus.concert;
 import jakarta.annotation.PreDestroy;
 
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
-@TestConfiguration
+import java.time.Duration;
+
+@Configuration
 public class TestcontainersConfiguration {
 
-	@Container
-	public static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-		.withDatabaseName("hhplus")
-			.withUsername("test")
-			.withPassword("test");
+	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
-	static  {
+	static {
+		// MySQL 컨테이너 설정 및 실행
+		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+				.withDatabaseName("hhplus")
+				.withUsername("test")
+				.withPassword("test");
 		MYSQL_CONTAINER.start();
 
+		// Redis 컨테이너 설정 및 실행
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:7.2.3"))
+				.withExposedPorts(6379)
+				.withStartupTimeout(Duration.ofSeconds(30));
+		REDIS_CONTAINER.start();
+
+		// MySQL 설정 - Spring Application에 주입
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
-		System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
-		System.setProperty("spring.jpa.show-sql", "true");
-		System.setProperty("spring.jpa.properties.hibernate.format-sql", "true");
+
+		// Redis 설정 - Spring Application에 주입
+		System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
 	}
 
+	// 테스트가 끝나면 컨테이너 종료
 	@PreDestroy
 	public void preDestroy() {
-		if ( MYSQL_CONTAINER.isRunning() ) {
+		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }
+

--- a/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
@@ -106,7 +106,7 @@ public class TemporaryReserveConcurrencyIntegrationTest {
 
 		// then
 		long successfulReservations = results.stream().filter(
-			temporaryReserveFuture -> {
+			temporaryReserveFuture -> {		// 결과를 담는 임시 변수 명
 				try {
 					return temporaryReserveFuture.get() != null;
 				} catch (Exception e) {
@@ -175,4 +175,48 @@ public class TemporaryReserveConcurrencyIntegrationTest {
 		}
 		assertEquals(1, successfulReservations, "오직 한명의 유저만 좌석 예약에 성공한다");
 	}
+
+	@Test
+	void Redis락_기반_동시예약_테스트_열명중_한명만_성공() throws InterruptedException {
+		// given
+		int threadCount = 10;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		List<Future<Boolean>> results = new ArrayList<>();
+
+		for (int i = 1; i <= threadCount; i++) {
+			final int index = i;
+			User user = userRepository.save(User.of("유저" + index));
+			ReservationCommand.TemporaryReserve command = ReservationCommand.TemporaryReserve.of(user, sampleConcertSeat);
+
+			results.add(executorService.submit(() -> {
+				latch.countDown();
+				latch.await();
+
+				try {
+					reservationService.temporaryReserve(command);
+					log.info("User{} 성공", index);
+					return true;
+				} catch (Exception e) {
+					log.info("User{} 실패: {}", index, e.getMessage());
+					return false;
+				}
+			}));
+		}
+
+		executorService.shutdown();
+		executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+		// then
+		long successCount = results.stream().filter(result -> {
+			try {
+				return result.get();
+			} catch (Exception e) {
+				return false;
+			}
+		}).count();
+
+		assertEquals(1, successCount, "오직 한 명만 락 획득 및 임시 예약에 성공해야 한다.");
+	}
+
 }

--- a/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
@@ -50,7 +50,7 @@ public class UserPointConcurrencyIntegrationTest {
 	void setUp() {
 		// truncate -> serUp -> 테스트케이스 수행 순으로 진행
 		// 유저 테스트 데이터 셋팅
-		sampleUser = User.of("최은강");
+		sampleUser = User.of("이동우");
 		userRepository.save(sampleUser);
 
 		sampleUserPoint = UserPoint.of(sampleUser); // 초기포인트 0 포인트
@@ -58,52 +58,31 @@ public class UserPointConcurrencyIntegrationTest {
 	}
 
 	@Test
-	@Order(1)
-	@Sql(statements = {
-		"SET SESSION innodb_lock_wait_timeout=10"
-	}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-	@Sql(statements = {
-		"SET SESSION innodb_lock_wait_timeout=50"
-	}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-	void 포인트_충전과_사용은_동시에_진행되어도_정합성이_깨지지_않아야_한다() throws Exception {
-		// given
+	void 동시에_여러요청이_들어와도_포인트는_한번만_충전된다() throws InterruptedException {
 		long userId = sampleUser.getId();
 
-		// 먼저 10,000원 충전
-		userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 10_000L));
+		int threadCount = 10;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
 
-		// 두 작업이 동시에 실행되도록 조율하는 CyclicBarrier
-		CyclicBarrier barrier = new CyclicBarrier(2);
-
-		ExecutorService executor = Executors.newFixedThreadPool(2);
-		List<Future<Long>> results = new ArrayList<>();
-
-		// 충전 쓰레드
-		results.add(executor.submit(() -> {
-			log.info("::: 포인트 충전 스레드 실행");
-			long start = System.currentTimeMillis();
-			barrier.await(); // 🔥 다른 스레드가 도달할 때까지 대기
-			userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 5_000L));
-			return System.currentTimeMillis() - start;
-		}));
-
-		// 사용 쓰레드
-		results.add(executor.submit(() -> {
-			log.info("::: 포인트 사용 스레드 실행");
-			long start = System.currentTimeMillis();
-			barrier.await(); // 🔥 두 스레드가 동시에 실행되도록 조율
-			userService.usePoint(UserPointCommand.UsePoint.of(userId, 5_000L));
-			return System.currentTimeMillis() - start;
-		}));
-
-		// when: 두 작업이 완료될 때까지 기다림
-		for (Future<Long> result : results) {
-			long executeTime = result.get(); // 예외 발생 시 여기서 잡힘
-			log.info("소요시간: {}ms", executeTime);
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					userService.chargePoint(new UserPointCommand.ChargePoint(userId, 1000L));
+				} catch (Exception e) {
+					// 중복 충전 시 예외 발생 가능 (락 획득 실패 등)
+					System.out.println("예외 발생: " + e.getMessage());
+				} finally {
+					latch.countDown();
+				}
+			});
 		}
 
-		// then: 최종 포인트는 10,000 + 5,000 - 5,000 = 10,000
-		UserInfo.GetCurrentPoint info = userService.getCurrentPoint(UserPointCommand.GetCurrentPoint.of(userId));
-		assertEquals(10_000L, info.point());
+		latch.await();
+
+		UserPoint result = userPointRepository.findByUserId(userId);
+		assertNotNull(result);
+		assertEquals(1000L, result.getPoint()); // 단 1번만 충전되었는지 확인
 	}
+
 }

--- a/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
@@ -1,20 +1,9 @@
 package io.hhplus.concert.domain.user;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.domain.reservation.TemporaryReserveConcurrencyIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
@@ -24,25 +13,32 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
-import io.hhplus.concert.TestcontainersConfiguration;
-import io.hhplus.concert.domain.concert.Concert;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {
-	"SET FOREIGN_KEY_CHECKS=0",
-	"TRUNCATE TABLE user_points",
-	"TRUNCATE TABLE user_point_histories",
-	"TRUNCATE TABLE users",
-	"SET FOREIGN_KEY_CHECKS=1"
+		"SET FOREIGN_KEY_CHECKS=0",
+		"TRUNCATE TABLE user_points",
+		"TRUNCATE TABLE user_point_histories",
+		"TRUNCATE TABLE users",
+		"SET FOREIGN_KEY_CHECKS=1"
 }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+
 public class UserPointConcurrencyIntegrationTest {
-	private static final Logger log = LoggerFactory.getLogger(UserPointConcurrencyIntegrationTest.class);
+
 	@Autowired private UserService userService;
 	@Autowired private UserRepository userRepository;
 	@Autowired private UserPointRepository userPointRepository;
 	@Autowired private UserPointHistoryRepository userPointHistoryRepository;
+
+	private static final Logger log = LoggerFactory.getLogger(TemporaryReserveConcurrencyIntegrationTest.class);
 
 	User sampleUser;
 	UserPoint sampleUserPoint;
@@ -53,8 +49,8 @@ public class UserPointConcurrencyIntegrationTest {
 		sampleUser = User.of("이동우");
 		userRepository.save(sampleUser);
 
-		sampleUserPoint = UserPoint.of(sampleUser); // 초기포인트 0 포인트
-		sampleUserPoint.charge(3000L);
+		sampleUserPoint = UserPoint.of(sampleUser);
+		sampleUserPoint.charge(2000L);
 		userPointRepository.save(sampleUserPoint);
 	}
 
@@ -62,7 +58,7 @@ public class UserPointConcurrencyIntegrationTest {
 	void 동시에_여러요청이_들어와도_포인트는_한번만_충전된다() throws InterruptedException {
 		long userId = sampleUser.getId();
 
-		int threadCount = 15;
+		int threadCount = 10;
 		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 		CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -72,7 +68,7 @@ public class UserPointConcurrencyIntegrationTest {
 					userService.chargePoint(new UserPointCommand.ChargePoint(userId, 1000L));
 				} catch (Exception e) {
 					// 중복 충전 시 예외 발생 가능 (락 획득 실패 등)
-					System.out.println("예외 발생: " + e.getMessage());
+					log.error("예외 발생: {}", e.getMessage(), e);
 				} finally {
 					latch.countDown();
 				}
@@ -83,7 +79,7 @@ public class UserPointConcurrencyIntegrationTest {
 
 		UserPoint result = userPointRepository.findByUserId(userId);
 		assertNotNull(result);
-		assertEquals(4000L, result.getPoint()); // 단 1번만 충전되었는지 확인
+		assertEquals(3000L, result.getPoint()); // 단 1번만 충전되었는지 확인
 	}
 
 	@Test
@@ -100,7 +96,7 @@ public class UserPointConcurrencyIntegrationTest {
 					userService.usePoint(new UserPointCommand.UsePoint(userId, 1000L));
 					return true;
 				} catch (Exception e) {
-					System.out.println("예외 발생: " + e.getMessage());
+					log.error("예외 발생: {}", e.getMessage(), e);
 					return false;
 				} finally {
 					latch.countDown();
@@ -113,6 +109,6 @@ public class UserPointConcurrencyIntegrationTest {
 
 		UserPoint result = userPointRepository.findByUserId(userId);
 		assertNotNull(result);
-		assertEquals(2000L, result.getPoint());
+		assertEquals(1000L, result.getPoint());
 	}
 }

--- a/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
@@ -54,6 +54,7 @@ public class UserPointConcurrencyIntegrationTest {
 		userRepository.save(sampleUser);
 
 		sampleUserPoint = UserPoint.of(sampleUser); // 초기포인트 0 포인트
+		sampleUserPoint.charge(3000L);
 		userPointRepository.save(sampleUserPoint);
 	}
 
@@ -61,7 +62,7 @@ public class UserPointConcurrencyIntegrationTest {
 	void 동시에_여러요청이_들어와도_포인트는_한번만_충전된다() throws InterruptedException {
 		long userId = sampleUser.getId();
 
-		int threadCount = 10;
+		int threadCount = 15;
 		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 		CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -82,7 +83,36 @@ public class UserPointConcurrencyIntegrationTest {
 
 		UserPoint result = userPointRepository.findByUserId(userId);
 		assertNotNull(result);
-		assertEquals(1000L, result.getPoint()); // 단 1번만 충전되었는지 확인
+		assertEquals(4000L, result.getPoint()); // 단 1번만 충전되었는지 확인
 	}
 
+	@Test
+	void 동시에_포인트_사용요청이_들어와도_한번만_사용된다() throws InterruptedException {
+		long userId = sampleUser.getId();
+
+		int threadCount = 10;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					userService.usePoint(new UserPointCommand.UsePoint(userId, 1000L));
+					return true;
+				} catch (Exception e) {
+					System.out.println("예외 발생: " + e.getMessage());
+					return false;
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+
+		UserPoint result = userPointRepository.findByUserId(userId);
+		assertNotNull(result);
+		assertEquals(2000L, result.getPoint());
+	}
 }


### PR DESCRIPTION
## 🔗 **커밋 링크**

[ step 11 ]

### 임시 예약 서비스
- Redis 의존성 추가: a72dad2c443533b1ade4416222e7c7279da9f38a
- Testcontainers를 이용한 Redis 컨테이너 설정: 840c039505d0a38e372adf2120058a94d9eb0d34
- Redis 설정 파일 구성: 9fb1eaecb112878e66be67e6b66af8654d4658ce,
- **RedissonConfig 추가 및 빈 등록:** 6f76d0ca3235025520aeb101c62de8032137fca8
- 분산 락 AOP 및 유틸 추가: fe891b790c65b9ded1db23b855ad45b2c08f221e
- 서비스 코드에 분산 락 적용: 6bfa3fea110f9c643de5916ff9031542caa159b3
- 동시성 통합 테스트 코드 추가: 362cb1d58abe3ee92fda1e6bd725eeff7b7a6333

### 포인트 충전
- Redis 기반 SimpleLock 관련 인프라 추가: da61709c79c424b195b7382b5c70f2dba4cf45e9
- UserService에 SimpleLock 적용: 3a542e739065907aea0d14790cca777cc765a839
- 동시성 통합 테스트 코드 추가: f2f6b6bfca7f4a7f44d0fd9b1491f503603dcc2f

### 포인트 사용
-  Redis 기반 SimpleLock 적용 및 통합 테스트 코드 추가:  f2f6b6b


## **리뷰 포인트(질문)**

- 각 서비스에 적합한 락을 적용했는지 궁급하니다.
- Redis 설정 정보를 사용하려고 RedisProperties를 주입하려 했는데,
생성자 주입이나 필드 주입, 그리고 @ConfigurationPropertiesScan("org.springframework.boot.autoconfigure.data.redis")도 시도해봤지만, 전부 주입이 되지 않아 결국 @EnableConfigurationProperties(RedisProperties.class)로 수동 등록해서 해결했습니다.
이 경우처럼 RedisProperties는 자동으로 Bean 등록이 안 되는 게 맞는 건가요?
그리고 이런 경우 수동으로 직접 등록해서 사용하는 방식이 일반적으로 맞는 접근인지 궁금합니다.
- 포인트 충전 로직에는 SimpleLock을 적용했을 때 하나의 트랜잭션만 정상적으로 수행되지만, 동일한 방식으로 락을 건 포인트 사용 로직에서는 두 개의 트랜잭션이 수행되는 현상이 발생합니다. 동일한 락 키를 사용함에도 불구하고 충전과는 다른 동작을 보이는 이유가 궁금합니다.

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
    
    좋은 예:
    
    - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
    - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.
    
    나쁜 예:
    
    - 개선사항을 알려주세요.
    - 코드 전반적으로 봐주세요.
    - 뭘 질문할지 모르겠어요. -->

---

### **이번주 KPT 회고**

### Keep

습득하는 속도는 느리지만 하루 빠짐 없이 공부 했습니다.

### Problem

심화과제 까지는 제출하지 못 했습니다. 


### Try
다음주에는 심화 과제까지 할 수 있도록 노려해보겠습니다.
