### PR TITLE
Step13

### DIFF
--- a/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertCriteria.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertCriteria.java
@@ -1,0 +1,17 @@
+package io.hhplus.concert.application.usecase.concert;
+
+import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
+
+import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.CONCERT_RANK_NOT_FOUND;
+
+public class ConcertCriteria {
+
+    public record GetRankOfConcert(String concertId) {
+        public static GetRankOfConcert of(String concertId) {
+            if (concertId == null || concertId.trim().isEmpty()) {
+                throw new InvalidValidationException(CONCERT_RANK_NOT_FOUND);
+            }
+            return new GetRankOfConcert(concertId);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertResult.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertResult.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.application.usecase.concert;
+
+import java.util.List;
+
+public class ConcertResult {
+
+    public record TopSellingConcerts(List<String> concertIds) {
+        public static TopSellingConcerts of(List<String> concertIds) {
+            return new TopSellingConcerts(concertIds);
+        }
+    }
+
+    public record ConcertRank(String concertId, long rank) {
+        public static ConcertRank of(String concertId, long rank) {
+            return new ConcertRank(concertId, rank);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/concert/ConcertUsecase.java
@@ -1,0 +1,33 @@
+package io.hhplus.concert.application.usecase.concert;
+
+import io.hhplus.concert.domain.concert.ConcertSalesRankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertUsecase {
+
+    private final ConcertSalesRankingService concertSalesRankingService;
+
+    /**
+     * 인기 콘서트 TOP5 목록 조회
+     */
+    public ConcertResult.TopSellingConcerts getTop5Concerts() {
+        List<String> topConcerts = concertSalesRankingService.getTopSellingConcerts();
+        return ConcertResult.TopSellingConcerts.of(topConcerts);
+    }
+
+    /**
+     * 특정 콘서트의 인기 순위 조회
+     */
+    public ConcertResult.ConcertRank getConcertRank(ConcertCriteria.GetRankOfConcert criteria) {
+        Integer rank = concertSalesRankingService.getRankOfConcert(criteria.concertId());
+        if (rank == null) {
+            throw new RuntimeException("해당 콘서트의 랭킹 정보를 찾을 수 없습니다.");
+        }
+        return ConcertResult.ConcertRank.of(criteria.concertId(), rank);
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/payment/PaymentUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/payment/PaymentUsecase.java
@@ -1,31 +1,25 @@
 package io.hhplus.concert.application.usecase.payment;
 
-import static io.hhplus.concert.interfaces.api.payment.PaymentErrorCode.*;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import io.hhplus.concert.domain.concert.ConcertCommand;
-import io.hhplus.concert.domain.concert.ConcertInfo;
-import io.hhplus.concert.domain.concert.ConcertService;
 import io.hhplus.concert.domain.payment.PaymentCommand;
 import io.hhplus.concert.domain.payment.PaymentInfo;
+import io.hhplus.concert.domain.payment.PaymentService;
+import io.hhplus.concert.domain.reservation.Reservation;
 import io.hhplus.concert.domain.reservation.ReservationCommand;
 import io.hhplus.concert.domain.reservation.ReservationInfo;
-import io.hhplus.concert.domain.user.UserCommand;
+import io.hhplus.concert.domain.reservation.ReservationService;
 import io.hhplus.concert.domain.user.UserInfo;
 import io.hhplus.concert.domain.user.UserPoint;
 import io.hhplus.concert.domain.user.UserPointCommand;
+import io.hhplus.concert.domain.user.UserService;
+import io.hhplus.concert.event.PaymentEvent;
+import io.hhplus.concert.event.PaymentEventPublisher;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
-import io.hhplus.concert.domain.concert.ConcertSeat;
-import io.hhplus.concert.domain.payment.Payment;
-import io.hhplus.concert.domain.payment.PaymentService;
-import io.hhplus.concert.domain.reservation.Reservation;
-import io.hhplus.concert.domain.reservation.ReservationService;
-import io.hhplus.concert.domain.user.UserService;
-import io.hhplus.concert.interfaces.api.payment.PaymentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static io.hhplus.concert.interfaces.api.payment.PaymentErrorCode.NOT_VALID_STATUS_FOR_PAYMENT;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +27,7 @@ public class PaymentUsecase {
 	private final UserService userService;
 	private final ReservationService reservationService;
 	private final PaymentService paymentService;
+	private final PaymentEventPublisher eventPublisher;
 
 	/**
 	 * 임시예약 상태(5분간 좌석예약) 에서 결제 요청 유즈케이스<br><br>
@@ -64,6 +59,10 @@ public class PaymentUsecase {
 
 			// 결제처리 및 결제정보 반환
 			PaymentInfo.CreatePayment paymentInfo = paymentService.create(PaymentCommand.CreatePayment.of(reservation));
+
+			// 이벤트 발행
+			Long concertId = reservation.getConcertId();
+			eventPublisher.publishEvent(new PaymentEvent(concertId));
 			return PaymentResult.PayAndConfirm.of(paymentInfo);
 		}
 		throw new BusinessException(NOT_VALID_STATUS_FOR_PAYMENT);

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSalesRankingService.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSalesRankingService.java
@@ -1,0 +1,42 @@
+package io.hhplus.concert.domain.concert;
+
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.protocol.ScoredEntry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ConcertSalesRankingService {
+
+    private final RedissonClient redissonClient;
+
+    @Autowired
+    public ConcertSalesRankingService(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
+    }
+
+    public List<String> getTopSellingConcerts() {
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet("concert:sales:");
+        if(set.isExists()) {
+            return set.entryRangeReversed(0, 4).stream()
+                    .map(ScoredEntry::getValue)  // Entry가 아니라 ScoredEntry!
+                    .collect(Collectors.toList());
+        } else {
+            throw new RuntimeException("순위를 매길 수 있는 콘서트가 없습니다.");
+        }
+    }
+
+    public Integer getRankOfConcert(String concertId) {
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet("concert:sales:");
+        if(set.isExists()) {
+            return set.revRank(concertId) + 1; // 순위는 1부터 시작하므로, +1을 추가한다.
+        } else {
+            throw new RuntimeException("해당 콘서트의 판매 순위를 구할 수 없습니다.");
+        }
+    }
+}
+

--- a/src/main/java/io/hhplus/concert/event/PaymentEvent.java
+++ b/src/main/java/io/hhplus/concert/event/PaymentEvent.java
@@ -1,0 +1,12 @@
+package io.hhplus.concert.event;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentEvent {
+    private final Long concertId;
+
+    public PaymentEvent(Long concertId) {
+        this.concertId = concertId;
+    }
+}

--- a/src/main/java/io/hhplus/concert/event/PaymentEventPublisher.java
+++ b/src/main/java/io/hhplus/concert/event/PaymentEventPublisher.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public PaymentEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void publishEvent(PaymentEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/config/RedisConfig.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/config/RedisConfig.java
@@ -1,6 +1,6 @@
-package io.hhplus.concert.domain.user;
+package io.hhplus.concert.infrastructure.config;
 
-import io.hhplus.concert.domain.reservation.RedisProperties;
+import io.hhplus.concert.infrastructure.config.RedisProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/io/hhplus/concert/infrastructure/config/RedisProperties.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/config/RedisProperties.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.reservation;
+package io.hhplus.concert.infrastructure.config;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/io/hhplus/concert/infrastructure/config/RedissonConfig.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/config/RedissonConfig.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.reservation;
+package io.hhplus.concert.infrastructure.config;
 
 import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;

--- a/src/main/java/io/hhplus/concert/infrastructure/lock/common/user/RedisSimpleLock.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/lock/common/user/RedisSimpleLock.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.user;
+package io.hhplus.concert.infrastructure.lock.common.user;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/io/hhplus/concert/infrastructure/lock/common/user/RedisSimpleLockAspect.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/lock/common/user/RedisSimpleLockAspect.java
@@ -1,6 +1,6 @@
-package io.hhplus.concert.domain.user;
+package io.hhplus.concert.infrastructure.lock.common.user;
 
-import io.hhplus.concert.domain.reservation.SpELParser;
+import io.hhplus.concert.infrastructure.lock.reservation.SpELParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -13,9 +13,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.UUID;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Order(1)
 @Aspect

--- a/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/DistributedLock.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/DistributedLock.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.reservation;
+package io.hhplus.concert.infrastructure.lock.reservation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/RedisDistributedLockAspect.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/RedisDistributedLockAspect.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.reservation;
+package io.hhplus.concert.infrastructure.lock.reservation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/SpELParser.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/lock/reservation/SpELParser.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.domain.reservation;
+package io.hhplus.concert.infrastructure.lock.reservation;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.ExpressionParser;

--- a/src/main/java/io/hhplus/concert/interfaces/listener/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/concert/interfaces/listener/PaymentEventListener.java
@@ -1,0 +1,28 @@
+package io.hhplus.concert.interfaces.listener;
+
+import io.hhplus.concert.event.PaymentEvent;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class PaymentEventListener {
+
+    private final RedissonClient redissonClient;
+
+    @Autowired
+    public PaymentEventListener(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompletedEvent(PaymentEvent event) {
+        RScoredSortedSet<Object> set = redissonClient.getScoredSortedSet("concert:sales:");
+        set.add(1, event.getConcertId().toString());
+    }
+}

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
@@ -1,12 +1,16 @@
 package io.hhplus.concert.application.usecase.payment;
 
-import static io.hhplus.concert.interfaces.api.payment.PaymentErrorCode.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
+import io.hhplus.concert.domain.concert.Concert;
+import io.hhplus.concert.domain.concert.ConcertDate;
+import io.hhplus.concert.domain.concert.ConcertSeat;
+import io.hhplus.concert.domain.payment.Payment;
+import io.hhplus.concert.domain.payment.PaymentCommand;
+import io.hhplus.concert.domain.payment.PaymentInfo;
+import io.hhplus.concert.domain.payment.PaymentService;
+import io.hhplus.concert.domain.reservation.*;
+import io.hhplus.concert.domain.user.*;
+import io.hhplus.concert.event.PaymentEventPublisher;
+import io.hhplus.concert.interfaces.api.common.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,27 +20,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.hhplus.concert.application.usecase.reservation.ReserveConcertSeatTest;
-import io.hhplus.concert.domain.concert.Concert;
-import io.hhplus.concert.domain.concert.ConcertDate;
-import io.hhplus.concert.domain.concert.ConcertSeat;
-import io.hhplus.concert.domain.payment.Payment;
-import io.hhplus.concert.domain.payment.PaymentCommand;
-import io.hhplus.concert.domain.payment.PaymentInfo;
-import io.hhplus.concert.domain.payment.PaymentService;
-import io.hhplus.concert.domain.reservation.Reservation;
-import io.hhplus.concert.domain.reservation.ReservationCommand;
-import io.hhplus.concert.domain.reservation.ReservationInfo;
-import io.hhplus.concert.domain.reservation.ReservationService;
-import io.hhplus.concert.domain.reservation.ReservationStatus;
-import io.hhplus.concert.domain.user.User;
-import io.hhplus.concert.domain.user.UserCommand;
-import io.hhplus.concert.domain.user.UserInfo;
-import io.hhplus.concert.domain.user.UserPoint;
-import io.hhplus.concert.domain.user.UserPointCommand;
-import io.hhplus.concert.domain.user.UserService;
-import io.hhplus.concert.interfaces.api.common.BusinessException;
-import io.hhplus.concert.interfaces.api.payment.PaymentResponse;
+import java.time.LocalDate;
+
+import static io.hhplus.concert.interfaces.api.payment.PaymentErrorCode.NOT_VALID_STATUS_FOR_PAYMENT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class PayAndConfirmTest {
@@ -48,10 +36,12 @@ public class PayAndConfirmTest {
 	private ReservationService reservationService;
 	@Mock
 	private PaymentService paymentService;
+	@Mock
+	private PaymentEventPublisher eventPublisher;
 
 	@BeforeEach
 	void setUp() {
-		paymentUsecase = new PaymentUsecase(userService, reservationService, paymentService);
+		paymentUsecase = new PaymentUsecase(userService, reservationService, paymentService, eventPublisher);
 	}
 	private static final Logger log = LoggerFactory.getLogger(PayAndConfirmTest.class);
 

--- a/src/test/java/io/hhplus/concert/domain/concert/ConcertSalesRankingServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/concert/ConcertSalesRankingServiceIntegrationTest.java
@@ -1,0 +1,81 @@
+package io.hhplus.concert.domain.concert;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class ConcertSalesRankingServiceIntegrationTest {
+
+    @Autowired
+    private ConcertSalesRankingService concertSalesRankingService;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @BeforeEach
+    void setUp() {
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet("concert:sales:");
+        set.clear();
+    }
+
+    @Test
+    void top5_콘서트를_조회한다() {
+        // given
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet("concert:sales:");
+        set.addScore("concert1", 5);
+        set.addScore("concert2", 10);
+        set.addScore("concert3", 3);
+        set.addScore("concert4", 8);
+        set.addScore("concert5", 1);
+
+        // when
+        List<String> topConcerts = concertSalesRankingService.getTopSellingConcerts();
+
+        // then
+        List<String> expectedOrder = List.of("concert2", "concert4", "concert1", "concert3", "concert5");
+        assertEquals(5, topConcerts.size());
+        assertIterableEquals(expectedOrder, new ArrayList<>(topConcerts));
+    }
+
+    @Test
+    void 특정_콘서트의_순위를_확인한다() {
+        // given
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet("concert:sales:");
+        set.addScore("concertA", 100);
+        set.addScore("concertB", 50);
+        set.addScore("concertC", 25);
+
+        // when
+        Integer rankA = concertSalesRankingService.getRankOfConcert("concertA");
+        Integer rankB = concertSalesRankingService.getRankOfConcert("concertB");
+        Integer rankC = concertSalesRankingService.getRankOfConcert("concertC");
+
+        // then
+        assertEquals(1, rankA);
+        assertEquals(2, rankB);
+        assertEquals(3, rankC);
+    }
+
+    @Test
+    void 랭킹정보가_없을때_예외를_발생시킨다() {
+        // given: Redis에 아무 데이터도 없음
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            concertSalesRankingService.getTopSellingConcerts();
+        });
+        assertEquals("순위를 매길 수 있는 콘서트가 없습니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## [STEP-13] 콘서트 랭킹 서비스

### 개요

Redis를 활용한 인기 콘서트 랭킹 기능 구현을 위해 아래 작업들을 진행했습니다.

### 주요 작업

1. **Redis 관련 파일 위치 변경: da62e00**
    - 기존 `domain`에 위치한 Redisson 설정 관련 파일들을 `infra` 계층으로 이동
    - 역할에 맞게 모듈 간 의존성 분리 및 정리
2. **인기 콘서트 랭킹 집계를 위한 이벤트 발행 기능 추가: 7aa6512**
    - 결제 완료 시 랭킹 반영을 위한 `PaymentEvent` 발행
    - `PaymentEventPublisher`, `PaymentEventListener` 구현
    - `PaymentUsecase.payAndConfirm()` 내부에 이벤트 발행 로직 추가
3. **인기 콘서트 랭킹 조회 서비스 구현 : 8151af5**
    - `ConcertSalesRankingService` 및 관련 Usecase/DTO(`ConcertUsecase`, `ConcertCriteria`, `ConcertResult`) 추가
    - 인기 콘서트 TOP5 조회, 특정 콘서트 순위 조회 기능 구현
    - 인기 콘서트 TOP5 조회 통합테스트 작성
    
    
### 리뷰 포인트(질문)
인기 콘서트 랭킹 조회 서비스 구현을 할 때 이렇게 이벤트를 활용하여 비동기적으로 집계하였는데, 옯바르게 구현했는지 궁금합니다.


## 이번주 KPT 회고
### Keep


### Problem
너무 늦게 과제에 몰입하여, 코치님께서 멘토링 해주신 부분을 다 적용하지 못했고, 모든 과제 제출을 못했습니다.

### Try
- 이벤트 리스너를 통해 어떤 이벤트가 발생했을 떄 비동기로 다른 작업을 수행하도록 구현 
